### PR TITLE
Fix list items appearing on next line when containing children.

### DIFF
--- a/src/main/java/com/pnikosis/html2markdown/MDLine.java
+++ b/src/main/java/com/pnikosis/html2markdown/MDLine.java
@@ -92,7 +92,11 @@ public class MDLine {
       newLine.append("----");
     }
 
-    newLine.append(getContent());
+    String contentStr = getContent();
+    if(type.equals(MDLineType.Unordered)){
+      contentStr = contentStr.replaceAll("^\n","");
+    }
+    newLine.append(contentStr);
 
     return newLine.toString();
   }


### PR DESCRIPTION
This is a special case fix addressing list items appearing on the next
line from their corresponding '*' character when they contain children.